### PR TITLE
update deps, bump version

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 var through = require('through')
 var toSource = require('tosource')
 
-var rcu = require('rcu/rcu.node')
+var rcu = require('rcu')
 
 rcu.init(require('ractive'))
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ractify",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "browserify 2 + precompiled Ractive.js components",
   "main": "index.js",
   "scripts": {
@@ -12,12 +12,12 @@
   },
   "dependencies": {
     "through": "2.3.4",
-    "rcu": "0.2.0",
+    "rcu": "0.4.0",
     "tosource": "0.1.2"
   },
   "devDependencies": {
     "mocha": "1.18.2",
-    "ractive": "0.5.4"
+    "ractive": "^0.7.2"
   },
   "browser": "runtime.js",
   "keywords": [


### PR DESCRIPTION
There's a [dependency](https://github.com/marcello3d/node-ractify/blob/master/package.json#L15) on rcu@0.2.0 - latest version is 0.4.0. Seems to be causing 'mismatched template version' errors.

Cheers!